### PR TITLE
feat: implement API key override via --key CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ caloohpay -r "PQRSTUV" -s "2024-01-01" -u "2024-01-31"
 # Specific timezone
 caloohpay -r "PQRSTUV" -t "America/New_York"
 
+# Override API token (useful for CI/CD or multiple accounts)
+caloohpay -r "PQRSTUV" -k "your_api_token_here"
+
 # Save to file
 caloohpay -r "PQRSTUV" -o "./payroll-report.csv"
 ```
@@ -239,7 +242,7 @@ Bob Wilson, 150, 3, 0
 
 ### Planned Features
 
-- [ ] **API Key Override**: CLI option `--key` implementation
+- [x] **API Key Override**: CLI option `--key` implementation ✅
 - [ ] **Multiple Timezone Support**: Full timezone handling for distributed teams
 - [ ] **CSV Output**: File generation for payroll systems
 - [ ] **Configurable Rates**: Custom weekday/weekend rates via config file

--- a/src/CalOohPay.ts
+++ b/src/CalOohPay.ts
@@ -15,8 +15,6 @@ import { DateTime } from "luxon";
 
 dotenv.config();
 
-const sanitisedEnvVars: Environment = sanitiseEnvVariable(process.env);
-
 const yargsInstance = yargs(hideBin(process.argv));
 
 const argv: CommandLineOptions = yargsInstance
@@ -137,7 +135,11 @@ function extractOnCallUsersFromFinalSchedule(finalSchedule: FinalSchedule): Reco
 
 function calOohPay(cliOptions: CommandLineOptions) {
     console.table(cliOptions);
+    
+    // Get API token from CLI option or environment variable
+    const sanitisedEnvVars: Environment = sanitiseEnvVariable(process.env, cliOptions.key);
     const pagerDutyApi = api({ token: sanitisedEnvVars.API_TOKEN });
+    
     for (const rotaId of cliOptions.rotaIds.split(',')) {
         pagerDutyApi
             .get(`/schedules/${rotaId}`,

--- a/src/EnvironmentController.ts
+++ b/src/EnvironmentController.ts
@@ -3,11 +3,14 @@ export interface Environment {
     API_TOKEN: string;
 }
 
-export function sanitiseEnvVariable(envVars: NodeJS.ProcessEnv): Environment {
-    if (!envVars.API_TOKEN) {
-        throw new Error("API_TOKEN not defined");
+export function sanitiseEnvVariable(envVars: NodeJS.ProcessEnv, apiKeyOverride?: string): Environment {
+    const apiToken = apiKeyOverride || envVars.API_TOKEN;
+    
+    if (!apiToken) {
+        throw new Error("API_TOKEN not defined. Please set API_TOKEN environment variable or use --key option.");
     }
+    
     return {
-        API_TOKEN: envVars.API_TOKEN,
+        API_TOKEN: apiToken,
     };
 }

--- a/test/EnvironmentController.test.ts
+++ b/test/EnvironmentController.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from '@jest/globals';
+import { sanitiseEnvVariable } from '../src/EnvironmentController';
+
+describe('EnvironmentController', () => {
+    describe('sanitiseEnvVariable', () => {
+        test('should return API_TOKEN from environment variables when no override provided', () => {
+            const envVars = { API_TOKEN: 'env-token-123' };
+            const result = sanitiseEnvVariable(envVars);
+            expect(result.API_TOKEN).toBe('env-token-123');
+        });
+
+        test('should use API key override when provided', () => {
+            const envVars = { API_TOKEN: 'env-token-123' };
+            const result = sanitiseEnvVariable(envVars, 'override-token-456');
+            expect(result.API_TOKEN).toBe('override-token-456');
+        });
+
+        test('should use API key override even when env var is not set', () => {
+            const envVars = {};
+            const result = sanitiseEnvVariable(envVars, 'override-token-789');
+            expect(result.API_TOKEN).toBe('override-token-789');
+        });
+
+        test('should throw error when neither env var nor override is provided', () => {
+            const envVars = {};
+            expect(() => sanitiseEnvVariable(envVars)).toThrow(
+                'API_TOKEN not defined. Please set API_TOKEN environment variable or use --key option.'
+            );
+        });
+
+        test('should throw error when env var is undefined and no override provided', () => {
+            const envVars = { API_TOKEN: undefined };
+            expect(() => sanitiseEnvVariable(envVars)).toThrow(
+                'API_TOKEN not defined. Please set API_TOKEN environment variable or use --key option.'
+            );
+        });
+
+        test('should prioritize override over environment variable', () => {
+            const envVars = { API_TOKEN: 'env-token' };
+            const result = sanitiseEnvVariable(envVars, 'cli-override-token');
+            expect(result.API_TOKEN).toBe('cli-override-token');
+        });
+    });
+});


### PR DESCRIPTION
- Add optional apiKeyOverride parameter to EnvironmentController.sanitiseEnvVariable()
- Update CalOohPay to pass CLI key option to environment controller
- Add comprehensive test suite for EnvironmentController (6 new tests)
- Update README with usage example and mark roadmap item complete
- Improve error message to mention both environment variable and CLI option