### PR TITLE
feat: add CSV output for payroll systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@ caloohpay -r "PQRSTUV" -t "America/New_York"
 # Override API token (useful for CI/CD or multiple accounts)
 caloohpay -r "PQRSTUV" -k "your_api_token_here"
 
-# Save to file
+# Save to CSV file (Google Sheets compatible)
 caloohpay -r "PQRSTUV" -o "./payroll-report.csv"
+
+# Multiple schedules to CSV
+caloohpay -r "PQRSTUV,PSTUVQR" -o "./monthly-oncall-report.csv"
 ```
 
 ### Sample Output
@@ -218,6 +221,45 @@ Jane Doe, 200, 4, 0
 Bob Wilson, 150, 3, 0
 ```
 
+### CSV Output Format
+
+When using the `--output-file` option, CalOohPay generates a Google Sheets compatible CSV file containing all schedule information and compensation data.
+
+#### CSV Structure
+
+```csv
+Schedule name:,Engineering Team Alpha
+Schedule URL:,https://company.pagerduty.com/schedules/PQRSTUV
+Using timezone:,Europe/London
+
+User,Total Compensation (£),Weekdays (Mon-Thu),Weekends (Fri-Sun)
+John Smith,275,3,2
+Jane Doe,200,4,0
+Bob Wilson,150,3,0
+```
+
+#### Features
+
+- **Google Sheets Compatible**: Open directly in Google Sheets or Excel
+- **Multiple Schedules**: When processing multiple schedules, each is appended to the same file
+- **Special Character Handling**: Automatically escapes commas, quotes, and newlines in names
+- **Payroll Ready**: Format designed for easy import into payroll systems
+
+#### Example Usage
+
+```bash
+# Single schedule to CSV
+caloohpay -r "PQRSTUV" -o "./august-oncall.csv"
+
+# Multiple schedules to one file
+caloohpay -r "TEAM_A,TEAM_B,TEAM_C" -o "./all-teams-august.csv"
+
+# Custom date range with CSV output
+caloohpay -r "PQRSTUV" -s "2024-01-01" -u "2024-01-31" -o "./january-oncall.csv"
+```
+
+The tool will always output to both the console AND the CSV file, so you can verify the data while generating reports.
+
 ## ✅ Current Features
 
 ### What Works
@@ -229,7 +271,8 @@ Bob Wilson, 150, 3, 0
 - ✅ **Distributed Teams**: Accurate OOH calculations across different timezones
 - ✅ **Payment Calculation**: Separate rates for weekdays/weekends
 - ✅ **Auditable Output**: User names, total compensation, and day breakdowns
-- ✅ **Comprehensive Testing**: 27 unit tests including timezone handling
+- ✅ **CSV Export**: Google Sheets compatible file output for payroll systems
+- ✅ **Comprehensive Testing**: 35 unit tests including timezone and CSV handling
 
 ### Default Behavior
 
@@ -284,10 +327,10 @@ Refer to [PagerDuty's timezone documentation](https://developer.pagerduty.com/do
 
 - [x] **API Key Override**: CLI option `--key` to override API token ✅
 - [x] **Full Timezone Support**: Uses schedule timezone from PagerDuty with optional override ✅
+- [x] **CSV Output**: Google Sheets compatible file generation for payroll systems ✅
 
 ### Planned Features
 
-- [ ] **CSV Output**: File generation for payroll systems
 - [ ] **Configurable Rates**: Custom weekday/weekend rates via config file
 - [ ] **Enhanced Output**: Colored console output and better formatting
 - [ ] **Package Distribution**: NPM package for easier installation

--- a/src/CsvWriter.ts
+++ b/src/CsvWriter.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { OnCallCompensation } from './OnCallCompensation';
+
+/**
+ * Writes on-call payment data to a CSV file compatible with Google Sheets.
+ */
+export class CsvWriter {
+    private filePath: string;
+
+    constructor(filePath: string) {
+        this.filePath = filePath;
+    }
+
+    /**
+     * Writes schedule information and compensation data to a CSV file.
+     * 
+     * @param scheduleName - Name of the PagerDuty schedule
+     * @param scheduleUrl - URL to the schedule in PagerDuty
+     * @param timezone - Timezone used for calculations
+     * @param auditableRecords - Record of user compensations
+     * @param append - Whether to append to existing file (for multiple schedules)
+     */
+    writeScheduleData(
+        scheduleName: string,
+        scheduleUrl: string,
+        timezone: string,
+        auditableRecords: Record<string, OnCallCompensation>,
+        append: boolean = false
+    ): void {
+        const lines: string[] = [];
+
+        // Add schedule information
+        lines.push(`Schedule name:,${this.escapeCsvValue(scheduleName)}`);
+        lines.push(`Schedule URL:,${this.escapeCsvValue(scheduleUrl)}`);
+        lines.push(`Using timezone:,${this.escapeCsvValue(timezone)}`);
+        lines.push(''); // Empty line for spacing
+
+        // Add header row
+        lines.push('User,Total Compensation (£),Weekdays (Mon-Thu),Weekends (Fri-Sun)');
+
+        // Add user compensation data
+        for (const [userId, onCallCompensation] of Object.entries(auditableRecords)) {
+            const userName = this.escapeCsvValue(onCallCompensation.OnCallUser.name);
+            const totalComp = onCallCompensation.totalCompensation;
+            const weekdays = onCallCompensation.OnCallUser.getTotalOohWeekDays();
+            const weekends = onCallCompensation.OnCallUser.getTotalOohWeekendDays();
+            
+            lines.push(`${userName},${totalComp},${weekdays},${weekends}`);
+        }
+
+        // Add empty line between schedules if appending
+        if (append) {
+            lines.push('');
+        }
+
+        this.writeToFile(lines.join('\n'), append);
+    }
+
+    /**
+     * Escapes special characters in CSV values.
+     * Wraps values in quotes if they contain commas, quotes, or newlines.
+     * 
+     * @param value - The value to escape
+     * @returns Escaped CSV value
+     */
+    private escapeCsvValue(value: string): string {
+        if (!value) {
+            return '';
+        }
+
+        // If value contains comma, quote, or newline, wrap in quotes and escape quotes
+        if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+            return `"${value.replace(/"/g, '""')}"`;
+        }
+
+        return value;
+    }
+
+    /**
+     * Writes content to the CSV file.
+     * Creates directories if they don't exist.
+     * 
+     * @param content - Content to write
+     * @param append - Whether to append or overwrite
+     */
+    private writeToFile(content: string, append: boolean): void {
+        try {
+            // Ensure directory exists
+            const dir = path.dirname(this.filePath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
+
+            // Write or append to file
+            if (append) {
+                fs.appendFileSync(this.filePath, '\n' + content, 'utf8');
+            } else {
+                fs.writeFileSync(this.filePath, content, 'utf8');
+            }
+        } catch (error) {
+            throw new Error(`Failed to write to file ${this.filePath}: ${error}`);
+        }
+    }
+
+    /**
+     * Checks if the CSV file already exists.
+     * 
+     * @returns True if file exists, false otherwise
+     */
+    fileExists(): boolean {
+        return fs.existsSync(this.filePath);
+    }
+
+    /**
+     * Deletes the CSV file if it exists.
+     */
+    deleteIfExists(): void {
+        if (this.fileExists()) {
+            fs.unlinkSync(this.filePath);
+        }
+    }
+}

--- a/test/CsvWriter.test.ts
+++ b/test/CsvWriter.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+import { CsvWriter } from '../src/CsvWriter';
+import { OnCallCompensation } from '../src/OnCallCompensation';
+import { OnCallUser } from '../src/OnCallUser';
+import { OnCallPeriod } from '../src/OnCallPeriod';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DateTime } from 'luxon';
+
+const testOutputDir = path.join(__dirname, 'test-output');
+const testFilePath = path.join(testOutputDir, 'test-output.csv');
+
+describe('CsvWriter', () => {
+    let csvWriter: CsvWriter;
+
+    beforeEach(() => {
+        // Ensure test output directory exists
+        if (!fs.existsSync(testOutputDir)) {
+            fs.mkdirSync(testOutputDir, { recursive: true });
+        }
+        csvWriter = new CsvWriter(testFilePath);
+        csvWriter.deleteIfExists();
+    });
+
+    afterEach(() => {
+        // Clean up test files
+        if (fs.existsSync(testFilePath)) {
+            fs.unlinkSync(testFilePath);
+        }
+    });
+
+    test('should create CSV file with schedule data', () => {
+        const onCallUser = new OnCallUser(
+            '1',
+            'John Doe',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-01T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const auditableRecords: Record<string, OnCallCompensation> = {
+            '1': {
+                OnCallUser: onCallUser,
+                totalCompensation: 275
+            }
+        };
+
+        csvWriter.writeScheduleData(
+            'Engineering Team',
+            'https://example.pagerduty.com/schedules/ABC123',
+            'Europe/London',
+            auditableRecords,
+            false
+        );
+
+        expect(csvWriter.fileExists()).toBe(true);
+
+        const content = fs.readFileSync(testFilePath, 'utf8');
+        expect(content).toContain('Schedule name:,Engineering Team');
+        expect(content).toContain('Schedule URL:,https://example.pagerduty.com/schedules/ABC123');
+        expect(content).toContain('Using timezone:,Europe/London');
+        expect(content).toContain('User,Total Compensation (£),Weekdays (Mon-Thu),Weekends (Fri-Sun)');
+        expect(content).toContain('John Doe,275,');
+    });
+
+    test('should handle multiple users in CSV output', () => {
+        const onCallUser1 = new OnCallUser(
+            '1',
+            'John Doe',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-01T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const onCallUser2 = new OnCallUser(
+            '2',
+            'Jane Smith',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-08T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const auditableRecords: Record<string, OnCallCompensation> = {
+            '1': {
+                OnCallUser: onCallUser1,
+                totalCompensation: 275
+            },
+            '2': {
+                OnCallUser: onCallUser2,
+                totalCompensation: 200
+            }
+        };
+
+        csvWriter.writeScheduleData(
+            'Engineering Team',
+            'https://example.pagerduty.com/schedules/ABC123',
+            'Europe/London',
+            auditableRecords,
+            false
+        );
+
+        const content = fs.readFileSync(testFilePath, 'utf8');
+        expect(content).toContain('John Doe,275,');
+        expect(content).toContain('Jane Smith,200,');
+    });
+
+    test('should append multiple schedules to the same file', () => {
+        const onCallUser1 = new OnCallUser(
+            '1',
+            'John Doe',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-01T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const onCallUser2 = new OnCallUser(
+            '2',
+            'Jane Smith',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-08T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const auditableRecords1: Record<string, OnCallCompensation> = {
+            '1': {
+                OnCallUser: onCallUser1,
+                totalCompensation: 275
+            }
+        };
+
+        const auditableRecords2: Record<string, OnCallCompensation> = {
+            '2': {
+                OnCallUser: onCallUser2,
+                totalCompensation: 200
+            }
+        };
+
+        // Write first schedule
+        csvWriter.writeScheduleData(
+            'Engineering Team Alpha',
+            'https://example.pagerduty.com/schedules/ABC123',
+            'Europe/London',
+            auditableRecords1,
+            false
+        );
+
+        // Append second schedule
+        csvWriter.writeScheduleData(
+            'Engineering Team Beta',
+            'https://example.pagerduty.com/schedules/DEF456',
+            'America/New_York',
+            auditableRecords2,
+            true
+        );
+
+        const content = fs.readFileSync(testFilePath, 'utf8');
+        
+        // Check first schedule
+        expect(content).toContain('Schedule name:,Engineering Team Alpha');
+        expect(content).toContain('John Doe,275,');
+        
+        // Check second schedule
+        expect(content).toContain('Schedule name:,Engineering Team Beta');
+        expect(content).toContain('Jane Smith,200,');
+        expect(content).toContain('America/New_York');
+    });
+
+    test('should escape CSV special characters in names', () => {
+        const onCallUser = new OnCallUser(
+            '1',
+            'Doe, John "Johnny"',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-01T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const auditableRecords: Record<string, OnCallCompensation> = {
+            '1': {
+                OnCallUser: onCallUser,
+                totalCompensation: 275
+            }
+        };
+
+        csvWriter.writeScheduleData(
+            'Team Name, with comma',
+            'https://example.pagerduty.com/schedules/ABC123',
+            'Europe/London',
+            auditableRecords,
+            false
+        );
+
+        const content = fs.readFileSync(testFilePath, 'utf8');
+        
+        // Check that comma in schedule name is escaped
+        expect(content).toContain('"Team Name, with comma"');
+        
+        // Check that user name with comma and quotes is properly escaped
+        expect(content).toContain('"Doe, John ""Johnny"""');
+    });
+
+    test('should create directories if they do not exist', () => {
+        const nestedPath = path.join(testOutputDir, 'nested', 'dir', 'output.csv');
+        const nestedCsvWriter = new CsvWriter(nestedPath);
+
+        const onCallUser = new OnCallUser(
+            '1',
+            'John Doe',
+            [
+                new OnCallPeriod(
+                    DateTime.fromISO('2024-08-01T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    DateTime.fromISO('2024-08-05T10:00:00+01:00', { zone: 'Europe/London' }).toJSDate(),
+                    'Europe/London'
+                )
+            ]
+        );
+
+        const auditableRecords: Record<string, OnCallCompensation> = {
+            '1': {
+                OnCallUser: onCallUser,
+                totalCompensation: 275
+            }
+        };
+
+        nestedCsvWriter.writeScheduleData(
+            'Engineering Team',
+            'https://example.pagerduty.com/schedules/ABC123',
+            'Europe/London',
+            auditableRecords,
+            false
+        );
+
+        expect(nestedCsvWriter.fileExists()).toBe(true);
+        expect(fs.existsSync(nestedPath)).toBe(true);
+
+        // Clean up
+        fs.unlinkSync(nestedPath);
+        fs.rmdirSync(path.join(testOutputDir, 'nested', 'dir'));
+        fs.rmdirSync(path.join(testOutputDir, 'nested'));
+    });
+
+    test('should handle empty auditable records', () => {
+        const auditableRecords: Record<string, OnCallCompensation> = {};
+
+        csvWriter.writeScheduleData(
+            'Empty Schedule',
+            'https://example.pagerduty.com/schedules/EMPTY',
+            'UTC',
+            auditableRecords,
+            false
+        );
+
+        const content = fs.readFileSync(testFilePath, 'utf8');
+        expect(content).toContain('Schedule name:,Empty Schedule');
+        expect(content).toContain('User,Total Compensation (£),Weekdays (Mon-Thu),Weekends (Fri-Sun)');
+        
+        // Should have header but no data rows
+        const lines = content.split('\n').filter(line => line.trim() !== '');
+        expect(lines.length).toBe(4); // 3 schedule info lines + 1 header
+    });
+
+    test('should delete existing file when deleteIfExists is called', () => {
+        // Create a file first
+        fs.writeFileSync(testFilePath, 'test content', 'utf8');
+        expect(fs.existsSync(testFilePath)).toBe(true);
+
+        // Delete it
+        csvWriter.deleteIfExists();
+        expect(fs.existsSync(testFilePath)).toBe(false);
+
+        // Calling again should not throw error
+        expect(() => csvWriter.deleteIfExists()).not.toThrow();
+    });
+
+    test('should correctly report file existence', () => {
+        expect(csvWriter.fileExists()).toBe(false);
+
+        fs.writeFileSync(testFilePath, 'test', 'utf8');
+        expect(csvWriter.fileExists()).toBe(true);
+
+        fs.unlinkSync(testFilePath);
+        expect(csvWriter.fileExists()).toBe(false);
+    });
+});


### PR DESCRIPTION
- Implement CsvWriter class for Google Sheets compatible CSV output
- Add --output-file (-o) CLI option support
- Write schedule information (name, URL, timezone) to CSV
- Include user compensation data with proper formatting
- Handle special characters (commas, quotes) in CSV values
- Support multiple schedules appended to single file
- Create directories automatically if they don't exist
- Add 8 comprehensive tests for CSV functionality
- Update README with CSV output documentation and examples
- Mark CSV output as completed in development roadmap

All output continues to display in console while also writing to CSV file. 35 tests passing (27 existing + 8 new CSV tests).