### PR TITLE
fix: preserve error context in CSV writer error handling

### DIFF
--- a/src/CsvWriter.ts
+++ b/src/CsvWriter.ts
@@ -270,7 +270,9 @@ export class CsvWriter {
                 this.logger.info(`Wrote CSV to ${this.filePath}`, { append });
             }
         } catch (error) {
-            throw new Error(`Failed to write to file ${this.filePath}: ${error}`);
+            const err = new Error(`Failed to write to file ${this.filePath}`);
+            err.cause = error;
+            throw err;
         }
     }
 


### PR DESCRIPTION
## Problem
When file write operations fail in CsvWriter, the error handling loses critical context by converting the original error to a string. This makes debugging production issues difficult, especially for file system errors like permission issues or disk full conditions.

## Solution
Modified the error re-throw to preserve the original error as the `cause` property of the new Error object. This maintains the full stack trace and underlying OS error details while still providing a meaningful error message.

## Changes
- Updated `writeToFile` method in `src/CsvWriter.ts`
- Changed from: `throw new Error(\`Failed to write to file ${this.filePath}: ${error}\`)`
- Changed to: Preserve original error via `Error.cause` property

## Testing
- ✅ All existing tests pass
- ✅ Lint checks pass
- ✅ TypeScript type checks pass
- ✅ Pre-commit hooks pass (lint + typecheck)
- ✅ Pre-push hooks pass (build + tests)

## Impact
- **Bug fix**: Improves debugging capabilities for file system errors
- **Breaking changes**: None
- **Risk level**: Low - only changes error handling, not business logic

## Related
Addresses Critical Issue #2 from the code quality analysis report.