### PR TITLE
docs: update compensation rate references to point to Constants.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See the [API Documentation](https://lonelydev.github.io/caloohpay/) for more det
 | **Weekdays** (Mon-Thu) | £50 per day |
 | **Weekends** (Fri-Sun) | £75 per day |
 
-> **Note**: Rates are currently hardcoded but can be modified in `src/OnCallPaymentsCalculator.ts`
+> **Note**: Compensation rates are defined in `src/Constants.ts` and can be modified there. The calculator references these centralized constants via `WEEKDAY_RATE` and `WEEKEND_RATE`.
 
 npm run dev
 npm run docs:serve

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,9 +56,11 @@ The core logic for determining if a shift qualifies as out-of-hours is in the `O
 
 ### Compensation Calculation
 
-Compensation rates are defined in `OnCallPaymentsCalculator`:
-- **Weekdays (Mon-Thu)**: £50 per day
-- **Weekends (Fri-Sun)**: £75 per day
+Compensation rates are defined in `Constants.ts` and referenced by `OnCallPaymentsCalculator`:
+- **Weekdays (Mon-Thu)**: £50 per day (`WEEKDAY_RATE` constant)
+- **Weekends (Fri-Sun)**: £75 per day (`WEEKEND_RATE` constant)
+
+To modify rates, update the values in `src/Constants.ts`.
 
 ### Timezone Support
 


### PR DESCRIPTION
- Update README.md note to reference Constants.ts instead of OnCallPaymentsCalculator.ts
- Update docs/index.md to clarify rates are defined in Constants.ts
- Add guidance on how to modify rates (update src/Constants.ts)
- Mention WEEKDAY_RATE and WEEKEND_RATE constant names for clarity

This change reflects the recent refactoring where compensation rates were extracted to a centralized Constants module for better maintainability.