### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lonelydev/caloohpay/security/code-scanning/1](https://github.com/lonelydev/caloohpay/security/code-scanning/1)

The best way to fix this problem is to add a minimal `permissions` block to limit the default permissions of the GITHUB_TOKEN used by this workflow. Since none of the existing steps require any write access, you can safely set permissions to `contents: read`. This should be added at the top level of the workflow file, just below the `name` field and above the `on` field, so it applies to all jobs in the workflow. No code within the job needs to be changed, and no new dependencies or imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
