### PR TITLE
feat: add automated npm publishing via GitHub Actions

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -46,7 +46,7 @@ Mock external dependencies; test boundaries and edge cases, not every path.
 
 ## Architecture
 
-- `src/core/`: Pure calculation, zero Node.js APIs → browser-safe
+- `src/core.ts`: Pure calculation, zero Node.js APIs → browser-safe
 - `src/node.ts`: CLI, file I/O, PagerDuty integration
 - Never import fs/path into core; pass config to browser code
 

--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -1,0 +1,82 @@
+---
+applyTo: '**'
+---
+
+# CalOohPay Development Guidelines
+
+Experienced polyglot engineer working on a production TypeScript CLI & browser-compatible library for on-call compensation calculations.
+
+## Core Principles
+
+- **Pragmatic over dogmatic**: Clean code without over-engineering
+- **Explicit over implicit**: Type safety is non-negotiable; no `any`
+- **Small, focused functions**: Self-documenting names matter
+- **Dual-runtime**: Core (browser-safe) lives separately from Node.js-specific APIs
+
+## TypeScript
+
+- Strict mode, explicit types, union/discriminated types
+- `readonly` for immutables; export minimally
+- Complex types get JSDoc comments
+
+## Testing: BDD + Pragmatism
+
+**Test**: Core business logic, public APIs, CLI workflows, integration points, error handling
+
+**Skip**: Trivial getters, external library behavior, implementation details
+
+Use Gherkin-style names:
+```typescript
+describe('Calculator', () => {
+  describe('given [context]', () => {
+    it('should [behavior]', () => { /* AAA */ });
+  });
+});
+```
+
+Mock external dependencies; test boundaries and edge cases, not every path.
+
+## Code Style
+
+- ES6 imports/exports; group by origin (external, then internal)
+- Async/await only; strict null checks; early returns
+- Errors: descriptive with context, never silent catches
+- Comments: explain *why*, not *what*
+- ESLint + Prettier on save
+
+## Architecture
+
+- `src/core/`: Pure calculation, zero Node.js APIs → browser-safe
+- `src/node.ts`: CLI, file I/O, PagerDuty integration
+- Never import fs/path into core; pass config to browser code
+
+## CLI
+
+- One command = one purpose
+- Specific, actionable error messages
+- Exit codes: 0 (success), 1 (error), 130 (interrupt)
+- Human-readable by default; `--json` for scripting
+- Concise help; link to docs for complexity
+
+## Commits & PRs
+
+- Conventional: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`
+- Atomic commits; focused PRs
+- Run `npm run verify` before pushing
+
+## Version Control
+
+Keep dependencies minimal. Prefer Node.js builtins. Audit regularly.
+
+## Deploy & Docs
+
+- JSDoc for public APIs with examples
+- Update CHANGELOG for breaking changes
+- Keep README focused on quick start
+
+## Security
+
+- Never log tokens/secrets
+- Validate CLI input
+- Environment variables for secrets
+- HTTPS for API calls

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Run tests
+        run: npm test
+      
+      - name: Run lint
+        run: npm run lint
+      
+      - name: Run typecheck
+        run: npm run typecheck
+      
+      - name: Build package
+        run: npm run build
+      
+      - name: Verify package contents
+        run: |
+          echo "Checking package contents..."
+          npm pack --dry-run
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Create summary
+        run: |
+          echo "## 🎉 Successfully Published to npm" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** caloohpay" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Release:** ${{ github.event.release.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View on npm: https://www.npmjs.com/package/caloohpay" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,9 +66,14 @@ jobs:
               echo "Consider if this warrants an npm publish. For docs-only changes,"
               echo "you may want to create releases without publishing to npm."
               echo ""
-              echo "If this IS intentional (e.g., docs in the package), comment this check or proceed."
-              # Note: Remove 'exit 1' below if you want to allow docs-only publishing
-              exit 1
+              echo "If this IS intentional (e.g., docs in the package), you can override this check"
+              echo "by setting the environment variable ALLOW_DOCS_ONLY_PUBLISH=true for this job."
+              if [ "${ALLOW_DOCS_ONLY_PUBLISH}" = "true" ]; then
+                echo "ℹ️  ALLOW_DOCS_ONLY_PUBLISH=true detected - proceeding with docs-only release."
+              else
+                echo "❌ Failing because no code changes were detected and ALLOW_DOCS_ONLY_PUBLISH is not set to 'true'."
+                exit 1
+              fi
             fi
             
             echo "✅ Code changes detected (not docs-only)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          fetch-tags: true
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,11 @@ jobs:
             echo "ℹ️  First release detected - skipping code change validation"
           else
             # Check if only docs, tests, and CI were changed
-            CHANGED_FILES=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" || git diff --name-only HEAD~1)
+            if ! CHANGED_FILES=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG"); then
+              echo "❌ Failed to compute diff between tags '$PREVIOUS_TAG' and '$RELEASE_TAG'."
+              echo "Ensure both tags exist and are reachable in the current repository history."
+              exit 1
+            fi
             
             # Filter for meaningful code changes (exclude docs, tests, CI, config)
             CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -v -E '^(docs/|test/|\.github/|README|CHANGELOG|\.eslintrc|\.prettierrc|tsconfig|jest\.config|commitlint|CONTRIBUTING|CODE_OF_CONDUCT|PUBLISHING|LICENSE|SECURITY)' || true)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          fetch-tags: true
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,58 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       
+      - name: Validate release version
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          
+          # Extract version from tag (remove 'v' prefix if present)
+          TAG_VERSION="${RELEASE_TAG#v}"
+          
+          if [[ "$TAG_VERSION" != "$PACKAGE_VERSION" ]]; then
+            echo "❌ Version mismatch!"
+            echo "Release tag: $RELEASE_TAG (resolves to v$TAG_VERSION)"
+            echo "package.json version: $PACKAGE_VERSION"
+            echo ""
+            echo "Please ensure the release tag matches the version in package.json"
+            exit 1
+          fi
+          echo "✅ Version match confirmed: $PACKAGE_VERSION"
+      
+      - name: Validate code changes (not docs-only)
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          
+          # Get the previous tag
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "$RELEASE_TAG"^ 2>/dev/null || echo "")
+          
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "ℹ️  First release detected - skipping code change validation"
+          else
+            # Check if only docs, tests, and CI were changed
+            CHANGED_FILES=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" || git diff --name-only HEAD~1)
+            
+            # Filter for meaningful code changes (exclude docs, tests, CI, config)
+            CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -v -E '^(docs/|test/|\.github/|README|CHANGELOG|\.eslintrc|\.prettierrc|tsconfig|jest\.config|commitlint|CONTRIBUTING|CODE_OF_CONDUCT|PUBLISHING|LICENSE|SECURITY)' || true)
+            
+            if [ -z "$CODE_CHANGES" ]; then
+              echo "⚠️  Warning: This release contains only documentation, tests, or CI changes"
+              echo "Changed files:"
+              echo "$CHANGED_FILES"
+              echo ""
+              echo "Consider if this warrants an npm publish. For docs-only changes,"
+              echo "you may want to create releases without publishing to npm."
+              echo ""
+              echo "If this IS intentional (e.g., docs in the package), comment this check or proceed."
+              # Note: Remove 'exit 1' below if you want to allow docs-only publishing
+              exit 1
+            fi
+            
+            echo "✅ Code changes detected (not docs-only)"
+            echo "Changed files:"
+            echo "$CODE_CHANGES"
+          fi
+      
       - name: Install dependencies
         run: npm ci
       
@@ -43,6 +95,32 @@ jobs:
         run: |
           echo "Checking package contents..."
           npm pack --dry-run
+          
+          # Verify key exports are present
+          echo ""
+          echo "Verifying compiled exports..."
+          
+          if [[ ! -f "dist/src/index.js" ]] || [[ ! -f "dist/src/index.d.ts" ]]; then
+            echo "❌ Main export files missing"
+            exit 1
+          fi
+          
+          if [[ ! -f "dist/src/core.js" ]] || [[ ! -f "dist/src/core.d.ts" ]]; then
+            echo "❌ Core export files missing"
+            exit 1
+          fi
+          
+          if [[ ! -f "dist/src/node.js" ]] || [[ ! -f "dist/src/node.d.ts" ]]; then
+            echo "❌ Node export files missing"
+            exit 1
+          fi
+          
+          if [[ ! -f "dist/src/CalOohPay.js" ]]; then
+            echo "❌ CLI executable missing"
+            exit 1
+          fi
+          
+          echo "✅ All package exports verified"
       
       - name: Publish to npm
         run: npm publish
@@ -53,8 +131,18 @@ jobs:
         run: |
           echo "## 🎉 Successfully Published to npm" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Release Details" >> $GITHUB_STEP_SUMMARY
           echo "**Package:** caloohpay" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Release:** ${{ github.event.release.name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "View on npm: https://www.npmjs.com/package/caloohpay" >> $GITHUB_STEP_SUMMARY
+          echo "### Validations Completed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Version tag matches package.json" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Code changes detected (not docs-only)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Tests passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Linting passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Type checking passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Package exports verified" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### View Package" >> $GITHUB_STEP_SUMMARY
+          echo "[🔗 View on npm](https://www.npmjs.com/package/caloohpay)" >> $GITHUB_STEP_SUMMARY

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -4,17 +4,86 @@ This document outlines the steps to publish CalOohPay to npm.
 
 ## Table of Contents
 
-- [Manual Release Process](#manual-release-process)
-- [Automated Release (Future)](#automated-release-future)
+- [Automated Release (Recommended)](#automated-release-recommended)
+- [Manual Release Process (Alternative)](#manual-release-process-alternative)
 - [NPM Token Setup](#npm-token-setup)
 - [Pre-Publishing Checklist](#pre-publishing-checklist)
 - [Troubleshooting](#troubleshooting)
 
-## Manual Release Process
+## Automated Release (Recommended)
 
-CalOohPay uses a semi-automated release script to streamline the publishing process.
+CalOohPay uses GitHub Actions to automatically publish to npm when you create a GitHub release.
 
 ### Quick Start
+
+```bash
+# 1. Update package.json version and CHANGELOG.md
+# 2. Commit your changes
+git add .
+git commit -m "chore: prepare release v2.1.0"
+
+# 3. Push to main branch
+git push origin main
+
+# 4. Create a GitHub release
+# Go to: https://github.com/lonelydev/caloohpay/releases/new
+# - Tag: v2.1.0
+# - Title: v2.1.0
+# - Description: Copy from CHANGELOG.md
+# - Click "Publish release"
+```
+
+The GitHub Actions workflow will automatically:
+1. Run all tests
+2. Run linting and type checking
+3. Build the package
+4. Publish to npm
+5. Create a summary with the npm package link
+
+### How It Works
+
+The automated publishing workflow (`.github/workflows/publish.yml`) triggers when you publish a GitHub release:
+
+1. **Trigger**: Publishing a GitHub release
+2. **Tests**: Runs `npm test`, `npm run lint`, `npm run typecheck`
+3. **Build**: Runs `npm run build`
+4. **Publish**: Uses `NPM_TOKEN` secret to publish to npm registry
+5. **Verification**: Checks package contents before publishing
+
+### Prerequisites
+
+- `NPM_TOKEN` must be configured in repository secrets (see [NPM Token Setup](#npm-token-setup))
+- All tests must pass
+- Version in `package.json` must match the release tag
+
+### Workflow File
+
+The automation is defined in `.github/workflows/publish.yml`:
+
+```yaml
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - Checkout code
+      - Setup Node.js
+      - Install dependencies
+      - Run tests, lint, typecheck
+      - Build package
+      - Publish to npm (using NPM_TOKEN)
+```
+
+## Manual Release Process (Alternative)
+
+If you prefer not to use the automated GitHub Actions workflow, you can use the release script.
+
+### Using the Release Script
 
 ```bash
 # 1. Update package.json version and CHANGELOG.md
@@ -103,19 +172,9 @@ npm publish
 # 4. Create GitHub release (see step 4 above)
 ```
 
-## Automated Release (Future)
-
-We plan to add automated npm publishing via GitHub Actions. This will:
-
-- Trigger when a GitHub release is created
-- Automatically run tests, build, and publish to npm
-- Require `NPM_TOKEN` secret configured in repository settings
-
-See [NPM Token Setup](#npm-token-setup) below for configuration details.
-
 ## NPM Token Setup
 
-For automated publishing (or for contributors who need to publish), an npm authentication token is required.
+For automated publishing via GitHub Actions, an npm authentication token is required.
 
 ### For Repository Maintainers
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -56,6 +56,26 @@ The automated publishing workflow (`.github/workflows/publish.yml`) triggers whe
 - All tests must pass
 - Version in `package.json` must match the release tag
 
+### Docs-Only Release Override
+
+The publish workflow blocks releases when the diff between the current tag and the previous tag contains only documentation, tests, CI, or config changes.
+
+If you intentionally want to publish a docs-only release, set the `ALLOW_DOCS_ONLY_PUBLISH` environment variable to `true` for the `publish` job in `.github/workflows/publish.yml`.
+
+Example:
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      ALLOW_DOCS_ONLY_PUBLISH: 'true'
+```
+
+Use this only when the npm package should still be republished even though no code changes were detected.
+
+For normal releases, leave this unset so the workflow continues to fail fast on docs-only changes.
+
 ### Workflow File
 
 The automation is defined in `.github/workflows/publish.yml`:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Example config file: [.caloohpay.json.example](https://github.com/lonelydev/calo
 
 Development, testing, contributor workflow and git-hook guidance has moved to [CONTRIBUTING.md](https://github.com/lonelydev/caloohpay/blob/main/CONTRIBUTING.md). Please read that document for detailed setup and contribution instructions, including how to run tests, lint, generate docs, and prepare a pull request.
 
+Release and npm publishing guidance has moved to [PUBLISHING.md](https://github.com/lonelydev/caloohpay/blob/main/PUBLISHING.md), including how to intentionally allow a docs-only publish with the `ALLOW_DOCS_ONLY_PUBLISH=true` workflow environment variable.
+
 Note on ESLint configuration: this project uses ESLint v9 with a flat config file located at `eslint.config.cjs` (instead of legacy `.eslintrc.json`). If you need to adjust lint rules or add new shareable configs, update `eslint.config.cjs` and run `npm run lint` to validate your changes.
 
 ## 🔧 Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -7808,9 +7808,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8794,9 +8794,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9500,9 +9500,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9510,6 +9510,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
- Create .github/workflows/publish.yml for automated npm publishing
- Workflow triggers on GitHub release publication
- Runs tests, lint, typecheck, and build before publishing
- Uses NPM_TOKEN secret for authentication
- Creates summary with npm package link
- Update PUBLISHING.md with automated release documentation
- Move manual release process to alternative section
- Document automated workflow prerequisites and usage
